### PR TITLE
Fix dependencies for eth2stats-client

### DIFF
--- a/l16/docker/docker-compose.prysm.yml
+++ b/l16/docker/docker-compose.prysm.yml
@@ -43,6 +43,7 @@ services:
     container_name: prysm_beacon
     depends_on:
       - geth
+      - eth2stats-client
     volumes:
       - $CONSENSUS_DATA_VOLUME:/consensus_data
       - $CONFIGS_VOLUME:/configs
@@ -68,8 +69,6 @@ services:
   prysm_validator:
     image: europe-docker.pkg.dev/lks-lz-artifacts/docker-prysm/validator:$PRYSM_BEACON_VERSION
     container_name: prysm_validator
-    depends_on:
-      - prysm_beacon
     volumes:
       - $KEYSTORE_VOLUME:/keystore
       - $VALIDATOR_DATA_VOLUME:/validator_data
@@ -91,8 +90,7 @@ services:
   eth2stats-client:
     image: macht/eth2stats-client:v1.0.0
     container_name: eth2stats-client
-    depends_on:
-      - prysm_beacon
+    restart: unless-stopped
     command: >
       run
       --beacon.type=prysm

--- a/l16/docker/docker-compose.prysm.yml
+++ b/l16/docker/docker-compose.prysm.yml
@@ -74,6 +74,8 @@ services:
       - $VALIDATOR_DATA_VOLUME:/validator_data
       - $CONFIGS_VOLUME:/configs
     restart: unless-stopped
+    depends_on:
+      - prysm_beacon
     stop_signal: SIGINT
     stop_grace_period: 2m
     command: >


### PR DESCRIPTION
Now allows eth2stats-client to restart when it failed, automatically starts eth2stats-client as a dependency for prysm