### PR TITLE
Fix template gas limit

### DIFF
--- a/l16/docker/docker-compose.prysm.yml
+++ b/l16/docker/docker-compose.prysm.yml
@@ -36,6 +36,7 @@ services:
       --port $GETH_PEER_PORT
       --http.port $GETH_HTTP_PORT 
       --ethstats "${NODE_NAME}@${ETH_STATS_ADDRESS}"
+      --miner.gaslimit 60000000
     network_mode: host
 
   prysm_beacon:


### PR DESCRIPTION
This PR increases the default gas limit (30M) for Geth client up to 60M. 