### PR TITLE
fix: remove p2p host 0.0.0.0 from prysm.yaml

### DIFF
--- a/mainnet/prysm/prysm.yaml
+++ b/mainnet/prysm/prysm.yaml
@@ -9,7 +9,6 @@ min-sync-peers: 0
 monitoring-host: 'localhost'
 grpc-gateway-host: 'localhost'
 rpc-host: 'localhost'
-p2p-host-ip: '0.0.0.0'
 p2p-max-peers: 250
 subscribe-all-subnets: true
 minimum-peers-per-subnet: 0

--- a/testnet/prysm/prysm.yaml
+++ b/testnet/prysm/prysm.yaml
@@ -9,7 +9,6 @@ min-sync-peers: 0
 monitoring-host: '0.0.0.0'
 grpc-gateway-host: '0.0.0.0'
 rpc-host: '0.0.0.0'
-p2p-host-ip: '0.0.0.0'
 p2p-max-peers: 250
 subscribe-all-subnets: true
 minimum-peers-per-subnet: 0


### PR DESCRIPTION
> --p2p-host-ip value: The IP address advertised by libp2p. This may be used to advertise an external IP.

https://docs.prylabs.network/docs/prysm-usage/parameters

The value 0.0.0.0 is not correct.
Clients should set their own