### PR TITLE
Added new chain config parameter - for new execution clients releases

### DIFF
--- a/devnets/7420/shared/genesis.json
+++ b/devnets/7420/shared/genesis.json
@@ -14,6 +14,7 @@
     "londonBlock": 0,
     "mergeForkBlock": 0,
     "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1684178926
   },
   "number": "0x0",

--- a/mainnet/shared/genesis.json
+++ b/mainnet/shared/genesis.json
@@ -14,6 +14,7 @@
     "londonBlock": 0,
     "mergeForkBlock": 0,
     "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1687969198
   },
   "number": "0x0",

--- a/testnet/shared/genesis.json
+++ b/testnet/shared/genesis.json
@@ -14,6 +14,7 @@
     "londonBlock": 0,
     "mergeForkBlock": 0,
     "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1683146926
   },
   "number": "0x0",


### PR DESCRIPTION
**General info**
This PR solves new `Geth` release issues (`geth v1.12.0`) caused by https://github.com/ethereum/go-ethereum/blob/dde2da0efb8e9a1812f470bc43254134cd1f8cc0/eth/ethconfig/config.go#L178 check.

**Story**
`go-ethereum` core implementation was based on TTD check `api.eth.Merger().TDDReached()`. In `Zhejiang` Ethereum test network (Shapella test) developers decided to stick to TTD consensus check instead of some boolean config value (TTD passed). That's why we don't see it in https://github.com/ethpandaops/withdrawals-testnet/blob/master/zhejiang-testnet/custom_config_data/genesis.json

I don't know what was the motivation behind, to get back to boolean flag in `geth v1.12.0` or missed `Merger().TDDReached()` consensus check, but this will require to change chain config and add this boolean value. This change won't affect genesis block hash, because this is how in future we will add more forks to the `genesis.json` (execution layer) and how execution clients are implemented. This change is irrelevant for `eth1data` and block hash.

Hash and state root are the same.

**`lukso-cli` impact**
@Wolmin We need to confirm that current `lukso-cli` downloads `mainnet/shared/genesis.json` (not the `genesis_X.json` files). This is because PR modifies only `mainnet/shared/genesis.json` config file.

**Checks**
- [X] Tested by https://github.com/lukso-network/tools-lodestar-genesis-ssz-generator (compared `eth1data` and hashes)
- [X] Tested by https://github.com/lukso-network/network-genesis-hash-calc (compared `eth1data` and hashes)
- [X] Change tested with `lukso start --testnet` (`v0.6.1`)