### PR TITLE
Feature: Open port 9090 from erigon

### DIFF
--- a/devnets/7420/erigon/erigon.toml
+++ b/devnets/7420/erigon/erigon.toml
@@ -17,7 +17,7 @@ http = true
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
-"private.api.addr" = "localhost:9091"
+"private.api.addr" = "localhost:9098"
 
 # ethstats = "${NODE_NAME}@${ETH_STATS_IP}"
 

--- a/devnets/7420/erigon/erigon.toml
+++ b/devnets/7420/erigon/erigon.toml
@@ -17,7 +17,7 @@ http = true
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
-"private.api.addr" = "localhost:9098"
+"private.api.addr" = "127.0.0.1:9098"
 
 # ethstats = "${NODE_NAME}@${ETH_STATS_IP}"
 

--- a/devnets/7420/erigon/erigon.toml
+++ b/devnets/7420/erigon/erigon.toml
@@ -17,6 +17,7 @@ http = true
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
+"private.api.addr" = "localhost:9091"
 
 # ethstats = "${NODE_NAME}@${ETH_STATS_IP}"
 

--- a/mainnet/erigon/erigon.toml
+++ b/mainnet/erigon/erigon.toml
@@ -16,6 +16,7 @@
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
+"private.api.addr" = "localhost:9091"
 
 # Bootnodes
 "bootnodes" = ["enode://c2bb19ce658cfdf1fecb45da599ee6c7bf36e5292efb3fb61303a0b2cd07f96c20ac9b376a464d687ac456675a2e4a44aec39a0509bcb4b6d8221eedec25aca2@34.147.73.193:30303", "enode://276f14e4049840a0f5aa5e568b772ab6639251149a52ba244647277175b83f47b135f3b3d8d846cf81a8e681684e37e9fc10ec205a9841d3ae219aa08aa9717b@34.32.192.211:30303"]

--- a/mainnet/erigon/erigon.toml
+++ b/mainnet/erigon/erigon.toml
@@ -16,7 +16,7 @@
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
-"private.api.addr" = "localhost:9098"
+"private.api.addr" = "127.0.0.1:9098"
 
 # Bootnodes
 "bootnodes" = ["enode://c2bb19ce658cfdf1fecb45da599ee6c7bf36e5292efb3fb61303a0b2cd07f96c20ac9b376a464d687ac456675a2e4a44aec39a0509bcb4b6d8221eedec25aca2@34.147.73.193:30303", "enode://276f14e4049840a0f5aa5e568b772ab6639251149a52ba244647277175b83f47b135f3b3d8d846cf81a8e681684e37e9fc10ec205a9841d3ae219aa08aa9717b@34.32.192.211:30303"]

--- a/mainnet/erigon/erigon.toml
+++ b/mainnet/erigon/erigon.toml
@@ -16,7 +16,7 @@
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
-"private.api.addr" = "localhost:9091"
+"private.api.addr" = "localhost:9098"
 
 # Bootnodes
 "bootnodes" = ["enode://c2bb19ce658cfdf1fecb45da599ee6c7bf36e5292efb3fb61303a0b2cd07f96c20ac9b376a464d687ac456675a2e4a44aec39a0509bcb4b6d8221eedec25aca2@34.147.73.193:30303", "enode://276f14e4049840a0f5aa5e568b772ab6639251149a52ba244647277175b83f47b135f3b3d8d846cf81a8e681684e37e9fc10ec205a9841d3ae219aa08aa9717b@34.32.192.211:30303"]

--- a/testnet/erigon/erigon.toml
+++ b/testnet/erigon/erigon.toml
@@ -16,6 +16,7 @@
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
+"private.api.addr" = "localhost:9091"
 
 # Bootnodes
 bootnodes = ["enode://c2bb19ce658cfdf1fecb45da599ee6c7bf36e5292efb3fb61303a0b2cd07f96c20ac9b376a464d687ac456675a2e4a44aec39a0509bcb4b6d8221eedec25aca2@34.141.196.212:30303","enode://4cee52dc3cdc0f9466d40354c0ae038b561eff0409f01092d44d692f35797a0f3e796481c5ad1ca9afb4ea00dcceaaddbf3a79ec311221bfad3567ba347e329b@34.91.156.224:30303"]

--- a/testnet/erigon/erigon.toml
+++ b/testnet/erigon/erigon.toml
@@ -16,7 +16,7 @@
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
-"private.api.addr" = "localhost:9098"
+"private.api.addr" = "127.0.0.1:9098"
 
 # Bootnodes
 bootnodes = ["enode://c2bb19ce658cfdf1fecb45da599ee6c7bf36e5292efb3fb61303a0b2cd07f96c20ac9b376a464d687ac456675a2e4a44aec39a0509bcb4b6d8221eedec25aca2@34.141.196.212:30303","enode://4cee52dc3cdc0f9466d40354c0ae038b561eff0409f01092d44d692f35797a0f3e796481c5ad1ca9afb4ea00dcceaaddbf3a79ec311221bfad3567ba347e329b@34.91.156.224:30303"]

--- a/testnet/erigon/erigon.toml
+++ b/testnet/erigon/erigon.toml
@@ -16,7 +16,7 @@
 "authrpc.vhosts" = "*"
 "snapshots" = false
 "prune" = "htc"
-"private.api.addr" = "localhost:9091"
+"private.api.addr" = "localhost:9098"
 
 # Bootnodes
 bootnodes = ["enode://c2bb19ce658cfdf1fecb45da599ee6c7bf36e5292efb3fb61303a0b2cd07f96c20ac9b376a464d687ac456675a2e4a44aec39a0509bcb4b6d8221eedec25aca2@34.141.196.212:30303","enode://4cee52dc3cdc0f9466d40354c0ae038b561eff0409f01092d44d692f35797a0f3e796481c5ad1ca9afb4ea00dcceaaddbf3a79ec311221bfad3567ba347e329b@34.91.156.224:30303"]


### PR DESCRIPTION
This PR includes a change to the default value of a `private.api.addr`, which allows us to keep the 9090 monitoring port open