### PR TITLE
fix: remove p2p host 0.0.0.0 from prysm.yaml

### DIFF
--- a/mainnet/prysm/prysm.yaml
+++ b/mainnet/prysm/prysm.yaml
@@ -9,7 +9,6 @@ min-sync-peers: 0
 monitoring-host: 'localhost'
 grpc-gateway-host: 'localhost'
 rpc-host: 'localhost'
-p2p-host-ip: '0.0.0.0'
 p2p-max-peers: 250
 subscribe-all-subnets: true
 minimum-peers-per-subnet: 0

--- a/testnet/prysm/prysm.yaml
+++ b/testnet/prysm/prysm.yaml
@@ -9,7 +9,6 @@ min-sync-peers: 0
 monitoring-host: '0.0.0.0'
 grpc-gateway-host: '0.0.0.0'
 rpc-host: '0.0.0.0'
-p2p-host-ip: '0.0.0.0'
 p2p-max-peers: 250
 subscribe-all-subnets: true
 minimum-peers-per-subnet: 0


### PR DESCRIPTION
I reopen this PR https://github.com/lukso-network/network-configs/pull/112 which I merged by accident. Cf conversation on the other PR.