### PR TITLE
feat: Geth miner gasprice

### DIFF
--- a/mainnet/geth/geth.toml
+++ b/mainnet/geth/geth.toml
@@ -8,7 +8,7 @@ NetworkId = 42
 
 [Eth.Miner]
 GasCeil = 42000000
-GasPrice = 4200000000  # 4.2 Gwei
+GasPrice = 1000000000  # 4.2 Gwei
 
 
 [Node]

--- a/mainnet/geth/geth.toml
+++ b/mainnet/geth/geth.toml
@@ -8,7 +8,7 @@ NetworkId = 42
 
 [Eth.Miner]
 GasCeil = 42000000
-GasPrice = 1000000000  # 4.2 Gwei
+GasPrice = 1000000000  # 1.0 Gwei
 
 
 [Node]

--- a/testnet/geth/geth.toml
+++ b/testnet/geth/geth.toml
@@ -7,7 +7,7 @@ NetworkId = 4201
 
 [Eth.Miner]
 GasCeil = 42000000
-GasPrice = 2200000000 # 2.2 Gwei
+GasPrice = 1000000000 # 1.0 Gwei
 
 
 [Node]


### PR DESCRIPTION
After upgrading Geth to v1.13.12, network validators noticed that after upgrading their node they trouble getting block rewards and putting transactions in blocks.
This PR introduces a change in minimum gas price required for transactions, which in turn results in a better block production performance.
 
Note: Minimum Gas Price is not a network level setting, but it is a node client level setting and validators are free to choose the value that they desire. It’s just a recommendation to change the gas price, because of Geth v1.13.12 fixes for miner.gasprice, but other validators are free to choose their own min gas price. However LUKSO recommends this value of 1 Gwei to prevent from any block production issues (TXs, rewards) on LUKSO Mainnet.
