### PR TITLE
Devnet Dencun fork epoch and Cancun timestamp

### DIFF
--- a/devnets/7420/shared/config.yaml
+++ b/devnets/7420/shared/config.yaml
@@ -58,10 +58,9 @@ CAPELLA_FORK_VERSION: 0x74200004
 CAPELLA_FORK_EPOCH: 42
 
 # Deneb
-# 18446744073709551615 is max uint64
-# It is set to far future epoch for now
+# GMT: Thursday, 21 March 2024 17:40:00
 DENEB_FORK_VERSION: 0x74200005
-DENEB_FORK_EPOCH: 18446744073709551615
+DENEB_FORK_EPOCH: 70000
 
 # Fork choice
 # ---------------------------------------------------------------

--- a/devnets/7420/shared/genesis.json
+++ b/devnets/7420/shared/genesis.json
@@ -16,7 +16,7 @@
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1684178926,
-    "cancunTime": 1767182400
+    "cancunTime": 1711042795
   },
   "number": "0x0",
   "nonce": "0x1",

--- a/devnets/7420/teku/config.yaml
+++ b/devnets/7420/teku/config.yaml
@@ -58,10 +58,9 @@ CAPELLA_FORK_VERSION: 0x74200004
 CAPELLA_FORK_EPOCH: 42
 
 # Deneb
-# 18446744073709551615 is max uint64
-# It is set to far future epoch for now
+# GMT: Thursday, 21 March 2024 17:40:00
 DENEB_FORK_VERSION: 0x74200005
-DENEB_FORK_EPOCH: 18446744073709551615
+DENEB_FORK_EPOCH: 70000
 
 # Fork choice
 # ---------------------------------------------------------------


### PR DESCRIPTION
This PR schedules LUKSO Devnet Dencun fork. `cancunTime` is calculated to start 5s before Deneb Fork Epoch: `# GMT: Thursday, 21 March 2024 17:40:00` minus `5s` = `# GMT: Thursday, 21 March 2024 17:39:55`