### PR TITLE
Add Pectra config variables

### DIFF
--- a/mainnet/shared/config.yaml
+++ b/mainnet/shared/config.yaml
@@ -64,6 +64,12 @@ CAPELLA_FORK_EPOCH: 8100
 DENEB_FORK_VERSION: 0x42000005
 DENEB_FORK_EPOCH: 123075
 
+# Electra
+# 18446744073709551615 is max uint64
+# It is set to far future epoch for now
+ELECTRA_FORK_VERSION: 0x42000006
+ELECTRA_FORK_EPOCH: 18446744073709551615
+
 # Fork choice
 # ---------------------------------------------------------------
 # 40%

--- a/mainnet/shared/genesis.json
+++ b/mainnet/shared/genesis.json
@@ -17,7 +17,8 @@
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1687969198,
-    "cancunTime": 1732119595
+    "cancunTime": 1732119595,
+    "pragueTime": 1795018800
   },
   "number": "0x0",
   "nonce": "0x1",

--- a/testnet/shared/config.yaml
+++ b/testnet/shared/config.yaml
@@ -61,6 +61,12 @@ CAPELLA_FORK_EPOCH: 42
 DENEB_FORK_VERSION: 0x42010005
 DENEB_FORK_EPOCH: 113400
 
+# Electra
+# 18446744073709551615 is max uint64
+# It is set to far future epoch for now
+ELECTRA_FORK_VERSION: 0x42010006
+ELECTRA_FORK_EPOCH: 18446744073709551615
+
 # Fork choice
 # ---------------------------------------------------------------
 # 40%

--- a/testnet/shared/genesis.json
+++ b/testnet/shared/genesis.json
@@ -18,7 +18,7 @@
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1683146926,
     "cancunTime": 1726676395,
-    "pragueTime": 1793809200
+    "pragueTime": 1791390000
   },
   "number": "0x0",
   "nonce": "0x1",

--- a/testnet/shared/genesis.json
+++ b/testnet/shared/genesis.json
@@ -18,7 +18,7 @@
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1683146926,
     "cancunTime": 1726676395,
-    "pragueTime": 1795018800
+    "pragueTime": 1793809200
   },
   "number": "0x0",
   "nonce": "0x1",

--- a/testnet/shared/genesis.json
+++ b/testnet/shared/genesis.json
@@ -17,7 +17,8 @@
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1683146926,
-    "cancunTime": 1726676395
+    "cancunTime": 1726676395,
+    "pragueTime": 1795018800
   },
   "number": "0x0",
   "nonce": "0x1",


### PR DESCRIPTION
This PR adds new `Pectra` CL config variables (far future epoch == max uint64 number). It also adds `pragueTime` far future timestamp to `genesis.json` ( `Wednesday, November 18, 2026 4:20:00 PM` GMT for now).

We will use far future epoch number and prague timestamp **to not fork** LUKSO Mainnet and Testnet before Ethereum Mainnet. It will allow to run the latest EL and CL clients in LUKSO networks (i.e. `Prysm` v5.1+ requires `config.yaml` with `Electra` fork specified. The same with `Erigon`. Otherwise it will fall back to Ethereum Mainnet fork epoch - which might be Feb 2025).

Electra is consensus layer fork name.
Prague is execution layer fork name.
Pectra is the combined name of EL an CL.

Pectra fork details: https://eips.ethereum.org/EIPS/eip-7600