### PR TITLE
Feat: Pectra Fork Timestamps

### DIFF
--- a/mainnet/nethermind/chainspec.json
+++ b/mainnet/nethermind/chainspec.json
@@ -57,7 +57,17 @@
     "eip4844TransitionTimestamp": "0x673E0C2B",
     "eip5656TransitionTimestamp": "0x673E0C2B",
     "eip6780TransitionTimestamp": "0x673E0C2B",
-    "eip7516TransitionTimestamp": "0x673E0C2B"
+    "eip7516TransitionTimestamp": "0x673E0C2B",
+    "eip7702TransitionTimestamp": "0x685AD030",
+    "eip7251TransitionTimestamp": "0x685AD030",
+    "eip7002TransitionTimestamp": "0x685AD030",
+    "eip6110TransitionTimestamp": "0x685AD030",
+    "eip7691TransitionTimestamp": "0x685AD030",
+    "eip7623TransitionTimestamp": "0x685AD030",
+    "eip7685TransitionTimestamp": "0x685AD030",
+    "eip7549TransitionTimestamp": "0x685AD030",
+    "eip2935TransitionTimestamp": "0x685AD030",
+    "eip2537TransitionTimestamp": "0x685AD030",
   },
   "genesis": {
     "number": "0x0",

--- a/mainnet/nimbus2/config.yaml
+++ b/mainnet/nimbus2/config.yaml
@@ -60,9 +60,14 @@ CAPELLA_FORK_VERSION: 0x42000004
 CAPELLA_FORK_EPOCH: 8100
 
 # Deneb
-# Date and time (GMT): Wednesday, 20 November 2024 16:20:00
+# Date and time: Wednesday, 20 November 2024 16:20:00 GMT
 DENEB_FORK_VERSION: 0x42000005
 DENEB_FORK_EPOCH: 123075
+
+# Electra
+# Date and time: Tuesday, 24 July 2025 16:20:00 GMT
+ELECTRA_FORK_VERSION: 0x42000006
+ELECTRA_FORK_EPOCH: 171675
 
 # Fork choice
 # ---------------------------------------------------------------
@@ -98,8 +103,8 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Validator Stakes
 # ---------------------------------------------------------------
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**10 * 10**9 (= 2,048,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 2048000000000
 # 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000
 

--- a/mainnet/shared/config.yaml
+++ b/mainnet/shared/config.yaml
@@ -60,15 +60,14 @@ CAPELLA_FORK_VERSION: 0x42000004
 CAPELLA_FORK_EPOCH: 8100
 
 # Deneb
-# Date and time (GMT): Wednesday, 20 November 2024 16:20:00
+# Date and time: Wednesday, 20 November 2024 16:20:00 GMT
 DENEB_FORK_VERSION: 0x42000005
 DENEB_FORK_EPOCH: 123075
 
 # Electra
-# 18446744073709551615 is max uint64
-# It is set to far future epoch for now
+# Date and time: Tuesday, 24 July 2025 16:20:00 GMT
 ELECTRA_FORK_VERSION: 0x42000006
-ELECTRA_FORK_EPOCH: 18446744073709551615
+ELECTRA_FORK_EPOCH: 171675
 
 # Fork choice
 # ---------------------------------------------------------------
@@ -110,7 +109,7 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Validator Stakes
 # ---------------------------------------------------------------
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**10 * 10**9 (= 2,048,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 2048000000000
 # 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000

--- a/mainnet/shared/genesis.json
+++ b/mainnet/shared/genesis.json
@@ -18,7 +18,7 @@
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 1687969198,
     "cancunTime": 1732119595,
-    "pragueTime": 1795018800
+    "pragueTime": 1750781995
   },
   "number": "0x0",
   "nonce": "0x1",

--- a/mainnet/teku/config.yaml
+++ b/mainnet/teku/config.yaml
@@ -60,9 +60,14 @@ CAPELLA_FORK_VERSION: 0x42000004
 CAPELLA_FORK_EPOCH: 8100
 
 # Deneb
-# Date and time (GMT): Wednesday, 20 November 2024 16:20:00
+# Date and time: Wednesday, 20 November 2024 16:20:00 GMT
 DENEB_FORK_VERSION: 0x42000005
 DENEB_FORK_EPOCH: 123075
+
+# Electra
+# Date and time: Tuesday, 24 July 2025 16:20:00 GMT
+ELECTRA_FORK_VERSION: 0x42000006
+ELECTRA_FORK_EPOCH: 171675
 
 # Fork choice
 # ---------------------------------------------------------------
@@ -106,8 +111,8 @@ MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT: 8
 
 # Validator Stakes
 # ---------------------------------------------------------------
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**10 * 10**9 (= 2,048,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 2048000000000
 # 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000
 

--- a/testnet/nethermind/chainspec.json
+++ b/testnet/nethermind/chainspec.json
@@ -58,6 +58,16 @@
     "eip5656TransitionTimestamp": "0x66EAFDAB",
     "eip6780TransitionTimestamp": "0x66EAFDAB",
     "eip7516TransitionTimestamp": "0x66EAFDAB"
+    "eip7702TransitionTimestamp": "0x68485B30",
+    "eip7251TransitionTimestamp": "0x68485B30",
+    "eip7002TransitionTimestamp": "0x68485B30",
+    "eip6110TransitionTimestamp": "0x68485B30",
+    "eip7691TransitionTimestamp": "0x68485B30",
+    "eip7623TransitionTimestamp": "0x68485B30",
+    "eip7685TransitionTimestamp": "0x68485B30",
+    "eip7549TransitionTimestamp": "0x68485B30",
+    "eip2935TransitionTimestamp": "0x68485B30",
+    "eip2537TransitionTimestamp": "0x68485B30",
   },
   "genesis": {
     "number": "0x0",

--- a/testnet/nimbus2/config.yaml
+++ b/testnet/nimbus2/config.yaml
@@ -57,9 +57,14 @@ CAPELLA_FORK_VERSION: 0x42010004
 CAPELLA_FORK_EPOCH: 42
 
 # Deneb
-# Date and time (GMT): Wednesday, 18 September 2024 16:20:00
+# Date and time: Wednesday, 18 September 2024 16:20:00 GMT
 DENEB_FORK_VERSION: 0x42010005
 DENEB_FORK_EPOCH: 113400
+
+# Electra
+# Date and time: Tuesday, 10 July 2025 16:20:00 GMT
+DENEB_FORK_VERSION: 0x42010006
+DENEB_FORK_EPOCH: 173025
 
 # Fork choice
 # ---------------------------------------------------------------
@@ -94,7 +99,7 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Validator Stakes
 # ---------------------------------------------------------------
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**10 * 10**9 (= 2,048,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 2048000000000
 # 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000

--- a/testnet/shared/config.yaml
+++ b/testnet/shared/config.yaml
@@ -57,15 +57,14 @@ CAPELLA_FORK_VERSION: 0x42010004
 CAPELLA_FORK_EPOCH: 42
 
 # Deneb
-# Date and time (GMT): Wednesday, 18 September 2024 16:20:00
+# Date and time: Wednesday, 18 September 2024 16:20:00 GMT
 DENEB_FORK_VERSION: 0x42010005
 DENEB_FORK_EPOCH: 113400
 
 # Electra
-# 18446744073709551615 is max uint64
-# It is set to far future epoch for now
-ELECTRA_FORK_VERSION: 0x42010006
-ELECTRA_FORK_EPOCH: 18446744073709551615
+# Date and time: Tuesday, 10 July 2025 16:20:00 GMT
+DENEB_FORK_VERSION: 0x42010006
+DENEB_FORK_EPOCH: 173025
 
 # Fork choice
 # ---------------------------------------------------------------
@@ -107,7 +106,7 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Validator Stakes
 # ---------------------------------------------------------------
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**10 * 10**9 (= 2,048,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 2048000000000
 # 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000

--- a/testnet/teku/config.yaml
+++ b/testnet/teku/config.yaml
@@ -57,9 +57,14 @@ CAPELLA_FORK_VERSION: 0x42010004
 CAPELLA_FORK_EPOCH: 42
 
 # Deneb
-# Date and time (GMT): Wednesday, 18 September 2024 16:20:00
+# Date and time: Wednesday, 18 September 2024 16:20:00 GMT
 DENEB_FORK_VERSION: 0x42010005
 DENEB_FORK_EPOCH: 113400
+
+# Electra
+# Date and time: Tuesday, 10 July 2025 16:20:00 GMT
+DENEB_FORK_VERSION: 0x42010006
+DENEB_FORK_EPOCH: 173025
 
 # Fork choice
 # ---------------------------------------------------------------
@@ -103,8 +108,8 @@ MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT: 8
 
 # Validator Stakes
 # ---------------------------------------------------------------
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**10 * 10**9 (= 2,048,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 2048000000000
 # 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000
 


### PR DESCRIPTION
This PR provides fork timestamps for Pectra Fork to occur on the following days:
- Testnet - 10th June 2025, 16:20:00 GMT
- Mainnet - 24th June 2025, 16:20:20 GMT
And raises the `MAX_EFFECTIVE_BALANCE` from 32 ETH (LYX) to 2048.