### PR TITLE
fix: Remove downloader from erigon flags

### DIFF
--- a/mainnet/erigon/erigon.toml
+++ b/mainnet/erigon/erigon.toml
@@ -15,6 +15,7 @@
 "authrpc.port" = 8551
 "authrpc.vhosts" = "*"
 "prune.mode" = "full"
+"no-downloader" = true
 "private.api.addr" = "127.0.0.1:9098"
 "db.size.limit" = "8TB" # optimal solution for erigon's breaking changes
 "maxpeers" = 100

--- a/testnet/erigon/erigon.toml
+++ b/testnet/erigon/erigon.toml
@@ -15,6 +15,7 @@
 "authrpc.port" = 8551
 "authrpc.vhosts" = "*"
 "prune.mode" = "full"
+"no-downloader" = true
 "private.api.addr" = "127.0.0.1:9098"
 "db.size.limit" = "8TB" # optimal solution for erigon's breaking changes
 "maxpeers" = 100


### PR DESCRIPTION
Since the downloader is enabled by default, it's good to keep it disabled to avoid littering the datadir