### PR TITLE
Fix/remove deprecated lh flag

### DIFF
--- a/mainnet/lighthouse/lighthouse.toml
+++ b/mainnet/lighthouse/lighthouse.toml
@@ -4,7 +4,6 @@ execution-jwt = "./configs/shared/secrets/jwt.hex"
 execution-endpoint = "http://localhost:8551"
 subscribe-all-subnets = true
 listen-address = "0.0.0.0"
-eth1 = true
 http = true
 http-port = 4000
 enr-udp-port = 9000

--- a/testnet/lighthouse/lighthouse.toml
+++ b/testnet/lighthouse/lighthouse.toml
@@ -4,7 +4,6 @@ execution-jwt = "./configs/shared/secrets/jwt.hex"
 execution-endpoint = "http://localhost:8551"
 subscribe-all-subnets = true
 listen-address = "0.0.0.0"
-eth1 = true
 http = true
 http-port = 4000
 enr-udp-port = 9000


### PR DESCRIPTION
This PR removes deprecated `eth1` flag from Lighthouse toml configuration due to Lighthouse Beacon client startup issue.