### PR TITLE
Clean up chainspec.json by removing EIP timestamps

### DIFF
--- a/mainnet/nethermind/chainspec.json
+++ b/mainnet/nethermind/chainspec.json
@@ -68,44 +68,9 @@
     "eip7549TransitionTimestamp": "0x68CADFB0",
     "eip2935TransitionTimestamp": "0x68CADFB0",
     "eip2537TransitionTimestamp": "0x68CADFB0",
-    "eip7594TransitionTimestamp": "0x967A7600",
-    "eip7892TransitionTimestamp": "0x967A7600",
-    "eip7918TransitionTimestamp": "0x967A7600",
-    "eip7825TransitionTimestamp": "0x967A7600",
-    "eip7935TransitionTimestamp": "0x967A7600",
-    "eip7934TransitionTimestamp": "0x967A7600",
-    "eip7883TransitionTimestamp": "0x967A7600",
-    "eip7642TransitionTimestamp": "0x967A7600",
-    "eip7951TransitionTimestamp": "0x967A7600",
-    "eip7939TransitionTimestamp": "0x967A7600",
-    "eip7910TransitionTimestamp": "0x967A7600",
-    "eip7917TransitionTimestamp": "0x967A7600",
     "eip7251ContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
     "eip7002ContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
-    "depositContractAddress": "0xCAfe00000000000000000000000000000000CAfe",
-    "blobSchedule": [
-      {
-        "name": "prague",
-        "timestamp": "0x967A7600",
-        "target": 6,
-        "max": 9,
-        "baseFeeUpdateFraction": "0x4c6964"
-      },
-      {
-        "name": "bpo1",
-        "timestamp": "0x967A7600",
-        "target": 10,
-        "max": 15,
-        "baseFeeUpdateFraction": "0x7f5a51"
-      },
-      {
-        "name": "bpo2",
-        "timestamp": "0x967A7600",
-        "target": 14,
-        "max": 21,
-        "baseFeeUpdateFraction": "0xb24b3f"
-      }
-    ]
+    "depositContractAddress": "0xCAfe00000000000000000000000000000000CAfe"
   },
   "genesis": {
     "number": "0x0",


### PR DESCRIPTION
Removed multiple EIP transition timestamps and blob schedule entries.